### PR TITLE
Only load API fields when on the settings or metabox pages in wp-admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Fixed
+- ActiveCampaign should only query the API for lists and tags when viewing wp-admin pages containing those fields. [#3]

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -7,16 +7,7 @@
  */
 function give_get_activecampaign_lists() {
 
-	global $post;
-
-	$post = isset($_GET['post']) ? $_GET['post'] : false;
-	$post = $post ? get_post($post) : false;
-
-	$is_settings_screen = ( isset( $_GET['tab'] ) && 'activecampaign' === $_GET['tab'] );
-	$is_form_edit_screen = ( $post && 'give_forms' === $post->post_type );
-
-	// This function only runs when viewing the option on the settings screen or metabox.
-	if ( ! $is_settings_screen && ! $is_form_edit_screen  )  {
+	if ( ! give_activecampaign_should_load_api_fields() ) {
 		return false;
 	}
 
@@ -55,9 +46,13 @@ function give_get_activecampaign_lists() {
 /**
  * Pull tags into
  *
- * @return array
+ * @return array|bool
  */
 function give_get_activecampaign_tags() {
+
+	if ( ! give_activecampaign_should_load_api_fields() ) {
+		return false;
+	}
 
 	$api_url = give_get_option( 'give_activecampaign_apiurl', false );
 	$api_key = give_get_option( 'give_activecampaign_api', false );
@@ -89,6 +84,29 @@ function give_get_activecampaign_tags() {
 	} else {
 		return array();
 	}
+
+}
+
+/**
+ * Should the API fields load in
+ *
+ * @return false
+ * @since 1.0.1
+ */
+function give_activecampaign_should_load_api_fields() {
+
+	$post = isset( $_GET['post'] ) ? $_GET['post'] : false;
+	$post = $post ? get_post( $post ) : false;
+
+	$is_settings_screen  = ( isset( $_GET['tab'] ) && 'activecampaign' === $_GET['tab'] );
+	$is_form_edit_screen = ( $post && 'give_forms' === $post->post_type );
+
+	// This function only runs when viewing the option on the settings screen or metabox.
+	if ( $is_settings_screen || $is_form_edit_screen ) {
+		return true;
+	}
+
+	return false;
 
 }
 

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -15,19 +15,19 @@ function give_get_activecampaign_lists() {
 	$api_key = give_get_option( 'give_activecampaign_api', false );
 
 	if ( ! $api_url || ! $api_key ) {
-		return array();
+		return [];
 	}
 
 	$ac = new ActiveCampaign( $api_url, $api_key );
 
-	$lists = $ac->api( 'list/list', array( 'ids' => 'all' ) );
+	$lists = $ac->api( 'list/list', [ 'ids' => 'all' ] );
 
 	if ( (int) $lists->success ) {
 
 		// We need to cast the object to an array because ActiveCampaign returns invalid JSON.
 		$lists = (array) $lists;
 
-		$output = array();
+		$output = [];
 
 		foreach ( $lists as $key => $list ) {
 			if ( ! is_numeric( $key ) ) {
@@ -39,7 +39,7 @@ function give_get_activecampaign_lists() {
 
 		return $output;
 	} else {
-		return array();
+		return [];
 	}
 }
 
@@ -58,18 +58,18 @@ function give_get_activecampaign_tags() {
 	$api_key = give_get_option( 'give_activecampaign_api', false );
 
 	if ( ! $api_url || ! $api_key ) {
-		return array();
+		return [];
 	}
 
 	$ac = new ActiveCampaign( $api_url, $api_key );
 
-	$tags = $ac->api( 'tags/list', array( 'ids' => 'all' ) );
+	$tags = $ac->api( 'tags/list', [ 'ids' => 'all' ] );
 
 	$tags = json_decode( $tags, true );
 
 	if ( ! empty( $tags ) ) {
 
-		$output = array();
+		$output = [];
 
 		foreach ( $tags as $key => $tag ) {
 			if ( ! is_numeric( $key ) ) {
@@ -82,7 +82,7 @@ function give_get_activecampaign_tags() {
 		return $output;
 
 	} else {
-		return array();
+		return [];
 	}
 
 }
@@ -90,11 +90,10 @@ function give_get_activecampaign_tags() {
 /**
  * Should the API fields load in
  *
- * @return false
  * @since 1.0.1
+ * @return bool
  */
 function give_activecampaign_should_load_api_fields() {
-
 	$post = isset( $_GET['post'] ) ? $_GET['post'] : false;
 	$post = $post ? get_post( $post ) : false;
 
@@ -102,12 +101,7 @@ function give_activecampaign_should_load_api_fields() {
 	$is_form_edit_screen = ( $post && 'give_forms' === $post->post_type );
 
 	// This function only runs when viewing the option on the settings screen or metabox.
-	if ( $is_settings_screen || $is_form_edit_screen ) {
-		return true;
-	}
-
-	return false;
-
+	return $is_settings_screen || $is_form_edit_screen;
 }
 
 /**
@@ -142,16 +136,16 @@ function give_activecampaign_display_optin( $form_id ) {
 	}
 
 	ob_start(); ?>
-	<fieldset id="give_activecampaign_<?php echo $form_id; ?>" class="give-activecampaign-fieldset">
-		<label for="give_activecampaign_<?php echo $form_id; ?>_signup" class="give-activecampaign-optin-label">
-			<input name="give_activecampaign_signup"
-			       class="give-activecampaign-optin-input"
-			       id="give_activecampaign_<?php echo $form_id; ?>_signup"
-			       type="checkbox" <?php echo( 'on' === $checked ? 'checked="checked"' : '' ); ?>/>
-			<span class="give-activecampaign-message-text"><?php echo $optin_label; ?></span>
-		</label>
+    <fieldset id="give_activecampaign_<?php echo $form_id; ?>" class="give-activecampaign-fieldset">
+        <label for="give_activecampaign_<?php echo $form_id; ?>_signup" class="give-activecampaign-optin-label">
+            <input name="give_activecampaign_signup"
+                   class="give-activecampaign-optin-input"
+                   id="give_activecampaign_<?php echo $form_id; ?>_signup"
+                   type="checkbox" <?php echo( 'on' === $checked ? 'checked="checked"' : '' ); ?>/>
+            <span class="give-activecampaign-message-text"><?php echo $optin_label; ?></span>
+        </label>
 
-	</fieldset>
+    </fieldset>
 	<?php
 	echo ob_get_clean();
 }
@@ -169,12 +163,12 @@ function give_activecampaign_donation_metabox_notification( $payment_id ) {
 	$opt_in_meta = give_get_meta( $payment_id, '_give_activecampaign_donation_optin_status', false );
 
 	if ( $opt_in_meta ) { ?>
-		<div class="give-admin-box-inside">
-			<p>
-				<span class="label"><?php _e( 'ActiveCampaign', 'give-activecampaign' ); ?>:</span>&nbsp;
-				<span><?php _e( 'Opted-in', 'give-activecampaign' ); ?></span>
-			</p>
-		</div>
+        <div class="give-admin-box-inside">
+            <p>
+                <span class="label"><?php _e( 'ActiveCampaign', 'give-activecampaign' ); ?>:</span>&nbsp;
+                <span><?php _e( 'Opted-in', 'give-activecampaign' ); ?></span>
+            </p>
+        </div>
 	<?php }
 
 }
@@ -187,7 +181,7 @@ add_filter( 'give_view_donation_details_totals_after', 'give_activecampaign_dona
  */
 function give_activecampaign_enqueue_admin_scripts() {
 	if ( give_is_admin_page() ) {
-		wp_register_script( 'give-activecampaign-admin', GIVE_ACTIVECAMPAIGN_URL . 'assets/js/give-activecampaign-admin.js', array( 'give-admin-scripts' ),
+		wp_register_script( 'give-activecampaign-admin', GIVE_ACTIVECAMPAIGN_URL . 'assets/js/give-activecampaign-admin.js', [ 'give-admin-scripts' ],
 			GIVE_ACTIVECAMPAIGN_VERSION, false );
 		wp_enqueue_script( 'give-activecampaign-admin' );
 	}

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -3,9 +3,22 @@
 /**
  * Get the lists from ActiveCampaign
  *
- * @return array
+ * @return array|bool
  */
 function give_get_activecampaign_lists() {
+
+	global $post;
+
+	$post = isset($_GET['post']) ? $_GET['post'] : false;
+	$post = $post ? get_post($post) : false;
+
+	$is_settings_screen = ( isset( $_GET['tab'] ) && 'activecampaign' === $_GET['tab'] );
+	$is_form_edit_screen = ( $post && 'give_forms' === $post->post_type );
+
+	// This function only runs when viewing the option on the settings screen or metabox.
+	if ( ! $is_settings_screen && ! $is_form_edit_screen  )  {
+		return false;
+	}
 
 	$api_url = give_get_option( 'give_activecampaign_apiurl', false );
 	$api_key = give_get_option( 'give_activecampaign_api', false );
@@ -104,10 +117,10 @@ function give_activecampaign_display_optin( $form_id ) {
 	// Is label and checked by default customized per form?
 	if ( 'customized' === $form_display_option ) {
 		$optin_label = give_get_meta( $form_id, 'give_activecampaign_label', true );
-		$checked = give_get_meta( $form_id, 'give_activecampaign_checkbox_default', true );
+		$checked     = give_get_meta( $form_id, 'give_activecampaign_checkbox_default', true );
 	} else {
 		$optin_label = give_get_option( 'give_activecampaign_label', esc_html__( 'Subscribe to our newsletter', 'give-activecampaign' ) );
-		$checked = give_get_option( 'give_activecampaign_checkbox_default', false );
+		$checked     = give_get_option( 'give_activecampaign_checkbox_default', false );
 	}
 
 	ob_start(); ?>
@@ -116,7 +129,7 @@ function give_activecampaign_display_optin( $form_id ) {
 			<input name="give_activecampaign_signup"
 			       class="give-activecampaign-optin-input"
 			       id="give_activecampaign_<?php echo $form_id; ?>_signup"
-			       type="checkbox" <?php echo(  'on' === $checked ? 'checked="checked"' : '' ); ?>/>
+			       type="checkbox" <?php echo( 'on' === $checked ? 'checked="checked"' : '' ); ?>/>
 			<span class="give-activecampaign-message-text"><?php echo $optin_label; ?></span>
 		</label>
 


### PR DESCRIPTION
<!-- Indicate the issue(s) resolved by this PR. -->

Resolves #2 

## Description

<!-- Summarize the related issue, explain HOW this PR solves the problem, and WHY you made the choices you made. -->

This resolves querying the AC API on non-GiveWP admin settings pages. This change will only load the field (tags and lists) when on the single donation form edit screen or the ActiveCampaign global settings tab.


## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [x] Relevant `@since` tags included in DocBlocks
-   [x] Changelog updated
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed

## Testing Instructions

<!-- Help others test your PR as efficiently as possible. -->
1. Pull down the plugin
2. View non-GiveWP admin settings pages in wp-admin
3. See if `give_get_activecampaign_tags()` or `give_get_activecampaign_lists()` passes the new condition (it shouldn't).
