### PR TITLE
refactor: update settings url for activation banner

### DIFF
--- a/give-activecampaign.php
+++ b/give-activecampaign.php
@@ -284,7 +284,7 @@ if ( ! class_exists( 'Give_ActiveCampaign' ) ) {
 					'file'              => GIVE_ACTIVECAMPAIGN_FILE,
 					'name'              => esc_html__( 'ActiveCampaign', 'give-activecampaign' ),
 					'version'           => GIVE_ACTIVECAMPAIGN_VERSION,
-					'settings_url'      => admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=give-activecampaign&section=activecampaign-settings' ),
+					'settings_url'      => admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=activecampaign' ),
 					'documentation_url' => 'http://docs.givewp.com/addon-activecampaign',
 					'support_url'       => 'https://givewp.com/support/',
 					'testing'           => false, // Never leave true.

--- a/includes/activation.php
+++ b/includes/activation.php
@@ -25,7 +25,7 @@ function give_activecampaign_plugin_action_links( $actions ) {
 	$new_actions = array(
 		'settings' => sprintf(
 			'<a href="%1$s">%2$s</a>',
-			admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=activecampaign&section=activecampaign-settings' ),
+			admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=activecampaign' ),
 			esc_html__( 'Settings', 'give-activecampaign' )
 		),
 	);


### PR DESCRIPTION
Resolves [GIVE-443]

## Description
This PR updates the URL path that the ActiveCampaign activation banner uses for the settings page.

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals


https://github.com/impress-org/give-activecampaign/assets/75056371/4aaac535-51c3-44e8-8fec-e3c2461fc661


## Testing Instructions
- Install Active Campaign
- Toward the top of the plugins page is an activation banner. Within the banner their is a link for the settings page. Verify that link works as expected.

## Pre-review Checklist
-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-443]: https://stellarwp.atlassian.net/browse/GIVE-443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ