### PR TITLE
refactor: validate array prior to adding tags on v2 forms

### DIFF
--- a/give-activecampaign.php
+++ b/give-activecampaign.php
@@ -431,9 +431,8 @@ if ( ! class_exists( 'Give_ActiveCampaign' ) ) {
 					"email"      => $user_info['email'],
 					"first_name" => $user_info['first_name'],
 					"last_name"  => $user_info['last_name'],
+                    "tags"       => implode( ', ', (array)$tags ),
 				];
-
-                is_array($tags) && $subscriber["tags" ] = implode( ', ', $tags );
 
 				foreach ( $lists as $list ) {
 					$subscriber["p[$list]"] = $list;

--- a/give-activecampaign.php
+++ b/give-activecampaign.php
@@ -431,8 +431,9 @@ if ( ! class_exists( 'Give_ActiveCampaign' ) ) {
 					"email"      => $user_info['email'],
 					"first_name" => $user_info['first_name'],
 					"last_name"  => $user_info['last_name'],
-					"tags"       => is_array($tags) && implode( ', ', $tags ),
 				];
+
+                is_array($tags) && $subscriber["tags" ] = implode( ', ', $tags );
 
 				foreach ( $lists as $list ) {
 					$subscriber["p[$list]"] = $list;

--- a/give-activecampaign.php
+++ b/give-activecampaign.php
@@ -431,7 +431,7 @@ if ( ! class_exists( 'Give_ActiveCampaign' ) ) {
 					"email"      => $user_info['email'],
 					"first_name" => $user_info['first_name'],
 					"last_name"  => $user_info['last_name'],
-					"tags"       => implode( ', ', $tags ),
+					"tags"       => is_array($tags) && implode( ', ', $tags ),
 				];
 
 				foreach ( $lists as $list ) {


### PR DESCRIPTION
Resolves [GIVE-776](https://stellarwp.atlassian.net/browse/GIVE-776)

## Description
This PR addresses a fatal error thrown on v2 forms when users customize per form settings and do not include tags. This is done by casting`$tags` as an array to handle empty string values from being imploded.

The error is thrown due to an array method `implode` being called on an empty string value. 

## Affects

<!-- Mention any existing functionality affected by this PR to help inform the reviewer(s). -->

## Visuals

https://github.com/impress-org/give-activecampaign/assets/75056371/9beb6058-0636-48dd-b0fa-8d900664ae68


## Testing Instructions
- Create a v2 form with ActiveCampaign
- Do NOT include tags in the settings
- Process a donation and verify no errors are thrown

## Pre-review Checklist

<!-- Complete tasks prior to requesting a review. Add to this list, but do not remove the base items. -->

-   [x] Acceptance criteria satisfied and marked in related issue
-   [ ] Relevant `@unreleased` tags included in DocBlocks
-   [ ] Includes unit tests
-   [ ] Reviewed by the designer (if follows a design)
-   [x] [Self Review](https://give.gitbook.io/development-manual/devops/github/code-reviews#self-review) of code and UX completed



[GIVE-776]: https://stellarwp.atlassian.net/browse/GIVE-776?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ